### PR TITLE
Fix typoed docco URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Marginalia 0.9.1
 
 ![marginalia](http://farm8.staticflickr.com/7057/6828224448_32b51e5784_z_d.jpg "Marginalia")
 
-*Ultra-lightweight literate programming[1] for [Clojure](http://clojure.org) and ClojureScript inspired by [docco](http://jashkenas.github.com/docco/)*
+*Ultra-lightweight literate programming[1] for [Clojure](http://clojure.org) and ClojureScript inspired by [docco](http://jashkenas.github.io/docco/)*
 
 Marginalia is a source code documentation tool that parses Clojure and ClojureScript code and outputs a side-by-side source view with appropriate comments and docstrings aligned.
 


### PR DESCRIPTION
[Fixes #177]