### PR TITLE
Fix fenceposting issue with docstring extraction

### DIFF
--- a/test/marginalia/parse_test.clj
+++ b/test/marginalia/parse_test.clj
@@ -6,7 +6,7 @@
 
 (deftest test-inline-literals
   (is (= (count (marginalia.parser/parse "(ns test)")) 1))
-  ;; (is (= (count (marginalia.parser/parse "(ns test)\n123")) 1)) ;; still failing
+  (is (= (count (marginalia.parser/parse "(ns test)\n123")) 1))
   (is (= (count (marginalia.parser/parse "(ns test)\n123\n")) 1))
   (is (= (count (marginalia.parser/parse "(ns test)\n\"string\"")) 1))
   (is (= (count (marginalia.parser/parse "(ns test)\n\"some string\"")) 1))


### PR DESCRIPTION
See the uncommented test.

Apologies for a noisy diff, [`?w=1` will help a lot](https://github.com/clj-commons/marginalia/pull/191/files?w=1).